### PR TITLE
Prepare v1.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Detailed GitHub Release notes continue to live in `changelogs/vX.Y.Z.txt`.
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-09-01
+
 ### Added
 
 - Added local Windows crash reports for main-thread Rust panics and native UI-loop errors
@@ -13,23 +15,35 @@ Detailed GitHub Release notes continue to live in `changelogs/vX.Y.Z.txt`.
 - Added a persistent Activity summary of the newest validated crash report after the next startup, so **Clear** does not hide the last crash context
 - Added a non-shipping Windows crash-capture probe for pre-Tokio panic and native-loop error ordering
 - Added Windows-only Event Log diagnostics, enabled by default after the first rendered frame, with sanitized Activity evidence
+- Added an opt-in Windows native crash-dump guide for failures that cannot be captured by the in-app report writer
+- Added per-rule descendant process management, disabled by default for newly created rules
 
 ### Changed
 
 - Returned both binaries to the platform system allocator instead of installing `mimalloc` globally
 - Stable Windows releases now publish an identity-verified matching PDB with line-table debug information for crash symbolization, and pull-request CI reproduces that symbol build
-- Schema v9 stores the Event Log diagnostics preference without a disclosure marker; schema v8 and older state adopts the enabled default without an eager rewrite
+- Process tracking and actions now bind a PID to verified process identity and creation time before applying affinity, priority, focus, or descendant ownership
+- Monitoring uses bounded event delivery and wakes the GUI directly instead of relying on an unbounded bridge or UI-thread sleeps
+- Tray commands are routed through the GUI thread; if tray initialization fails, the window remains reachable instead of hiding without a restore path
+- Persisted state schema is now v10. Existing pre-v10 rules preserve their previous descendant-management behavior, while newly created rules and missing v10 values default it to off
 
 ### Fixed
 
 - Kept overlapped named-pipe operation resources alive through every pending completion state, including cancellation and `ERROR_IO_INCOMPLETE`, preventing timeout-path use-after-free
 - Kept the saved-rule primary guard held until its forwarding server has stopped, preventing a replacement cold start from racing the previous named-pipe owner during shutdown
 - Prevented stale Event Log worker results from resurfacing after disable/re-enable, and kept Event Log evidence out of chronological Activity entries
+- Prevented PID reuse from redirecting runtime actions to a different process instance
+- Prevented unverified or older processes from being claimed as descendants of a tracked launch
+- Made state replacement crash-safe with validated temporary files and recovery backups instead of allowing an interrupted save to truncate the active state
+- Cleaned up suspended Windows launches when process setup fails before resume
+- Bounded monitor and IPC worker shutdown so stale workers cannot outlive the runtime state they serve
+- Updated `webbrowser` and `event-listener` to patched releases identified during the v1.6.0 dependency audit
 
 ### Security
 
 - Crash-report Explorer actions verify and execute through a non-elevated, below-high-integrity Explorer shell process; the existing Activity **Data folder** action keeps its prior direct-launch behavior
 - Crash report writes use unique partial files, no-replace publication, bounded UTF-8 content, reparse checks, and file-identity validation before managed deletion
+- Windows Event Log diagnostics are read-only, sanitize displayed fields, never upload data, and do not modify Windows Error Reporting or registry settings
 
 ## [1.5.0] - 2026-07-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,16 +848,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,7 +860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
+ "core-foundation",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -883,13 +873,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
+ "core-foundation",
  "libc",
 ]
 
 [[package]]
 name = "cpu-affinity-tool"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "eframe",
  "image",
@@ -983,7 +973,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1272,7 +1262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1292,11 +1282,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -2498,7 +2487,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3747,7 +3736,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4028,7 +4017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4110,7 +4099,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4364,7 +4353,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4390,7 +4379,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4734,15 +4723,15 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+checksum = "ef62a3d5f7b2411119a11b6f62570dbff91d7105e011a20fb83fbf8f5761c40f"
 dependencies = [
- "core-foundation 0.10.1",
  "jni",
  "log",
  "ndk-context",
  "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",
@@ -4895,7 +4884,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5194,7 +5183,7 @@ dependencies = [
  "calloop 0.13.0",
  "cfg_aliases",
  "concurrent-queue",
- "core-foundation 0.9.4",
+ "core-foundation",
  "core-graphics",
  "cursor-icon",
  "dpi",
@@ -5256,7 +5245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpu-affinity-tool" 
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 rust-version = "1.92"
 default-run = "cpu-affinity-tool"

--- a/changelogs/v1.6.0.txt
+++ b/changelogs/v1.6.0.txt
@@ -1,0 +1,58 @@
+## [1.6.0] - 2026-09-01
+
+### Summary
+- Improves Windows stability around process tracking, monitoring, tray handling, named-pipe forwarding, state persistence, and shutdown.
+- Adds local crash reports and read-only Windows Event Log evidence so users can provide better diagnostics after an unexpected exit.
+- Publishes matching Windows debug symbols for future native crash investigation.
+
+### Added
+- **Local Windows crash reports**:
+  - Main-thread Rust panics and native UI-loop errors can write a bounded local report before exit.
+  - The new **Activity → Crash reports** page lists validated reports, keeps the newest 20 complete reports, and supports confirmed deletion.
+  - After the next completed startup scan, Activity retains a summary of the newest validated report even after normal activity is cleared.
+  - Reports are stored only on the local machine and are never uploaded automatically. Review them before sharing because they can contain local paths or system details.
+- **Windows Event Log diagnostics**:
+  - Activity performs a bounded, read-only lookup for a recent matching Windows `Application Error` record after startup.
+  - Only sanitized fields are shown: record ID, UTC time, exception code, module basename, and valid optional module version, faulting offset, and process creation time.
+  - The lookup is enabled by default, can be disabled from Activity, uploads nothing, and does not modify Windows Error Reporting or the registry.
+- **Native crash investigation support**:
+  - Stable Windows releases now include `cpu_affinity_tool.pdb` matching the published executable.
+  - The repository includes a manual, opt-in LocalDumps guide for native failures that do not create an in-app report.
+- **Descendant process control**:
+  - Rules can explicitly opt in to managing verified descendant processes.
+  - New rules default to managing only their verified root process.
+
+### Changed
+- Returned the Windows application and Linux beta binary to the platform system allocator instead of installing `mimalloc` globally.
+- Bound tracked processes to verified identity and creation time so affinity, priority, focus, and monitoring actions do not trust a reused PID alone.
+- Routed tray commands through the GUI thread and kept the window reachable if tray initialization fails.
+- Replaced unbounded monitor event delivery with bounded delivery and explicit GUI wakeups.
+- Stable Windows builds now retain line-table debug information and must pass EXE/PDB identity validation before publication.
+- Persisted state schema is now v10:
+  - existing pre-v10 rules with no descendant-management field preserve the previously enabled behavior;
+  - newly created rules and missing v10 values default descendant management to off;
+  - the first explicit save upgrades older state to v10;
+  - pre-v6 state receives an additional `state.json.pre-v6*` backup before that save, while v6-v9 state does not;
+  - downgrade to an older binary is unsupported after the first v10 save.
+
+### Fixed
+- Kept Windows overlapped named-pipe state, event handles, and I/O buffers alive until Windows reports terminal completion, including cancellation and `ERROR_IO_INCOMPLETE` paths.
+- Kept the saved-rule primary guard held until the forwarding server and its workers have stopped.
+- Prevented PID reuse and unverified process identity from redirecting Run, Fix, Focus, affinity, or priority actions to a different process instance.
+- Required verified ancestry and creation ordering before a process can be managed as a descendant.
+- Cleaned up suspended child processes when Windows launch setup fails before resume.
+- Made state persistence crash-safe through validated temporary replacement and source-preserving recovery backups.
+- Prevented stale Event Log worker results from returning after diagnostics are disabled or restarted.
+- Avoided UI-thread sleeping in the hidden-window path and bounded monitor/IPC worker shutdown.
+- Updated `webbrowser` to 1.2.2 and `event-listener` to 5.4.2 to resolve the advisories identified during the release audit.
+
+### Known issues
+- The exact root cause of the native `0xc0000005` failure reported in issue #14 was not conclusively reproduced. This release mitigates multiple credible failure paths and adds diagnostics for further investigation.
+- A forced termination, native access violation, out-of-memory termination, stack overflow, power loss, background task panic, or anti-cheat/security action may stop the process before an in-app crash report can be written. Activity's Event Log evidence or the opt-in LocalDumps guide can help in those cases.
+- Stable release artifacts remain Windows-only. Linux continues as a separate desktop beta path without Windows tray, focus, installed-app activation, or saved-rule shortcut parity.
+- The release is not code signed and does not include an installer, winget, Chocolatey, AppImage, or Flatpak package.
+- Generated Windows shortcuts target the executable path used at creation time and should be recreated after moving the portable application folder.
+
+### Download
+- Download `cpu-affinity-tool.exe` from the GitHub Release assets for `v1.6.0`.
+- `cpu_affinity_tool.pdb` is provided for crash symbolization and is not required to run the application.

--- a/docs/dependency-advisories.md
+++ b/docs/dependency-advisories.md
@@ -4,7 +4,7 @@ This file records reviewed RustSec findings that remain in the lockfile so relea
 
 ## `quick-xml 0.39.4`
 
-Reviewed: 2026-07-16
+Reviewed: 2026-09-01
 
 Advisories:
 
@@ -25,7 +25,7 @@ Release assessment:
 
 Decision:
 
-Accept this as a build-time, non-user-input exposure for `v1.5.0`. Do not remove Wayland beta support or vendor a private scanner fork solely to force the transitive upgrade. Re-evaluate when `wayland-scanner` accepts `quick-xml >=0.41.0`, when the GUI stack is updated, or if the dependency begins parsing untrusted XML.
+Accept this as a build-time, non-user-input exposure for `v1.6.0`. Do not remove Wayland beta support or vendor a private scanner fork solely to force the transitive upgrade. Re-evaluate when `wayland-scanner` accepts `quick-xml >=0.41.0`, when the GUI stack is updated, or if the dependency begins parsing untrusted XML.
 
 Audit command for the reviewed lockfile:
 
@@ -34,3 +34,9 @@ cargo audit --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195
 ```
 
 The unignored audit must still be inspected so new advisories cannot hide behind these two reviewed exceptions.
+
+## Resolved during the `v1.6.0` review
+
+- Updated `webbrowser` from 1.2.1 to 1.2.2, resolving `RUSTSEC-2026-0257` in the Unix `BROWSER` handling path.
+- Updated `event-listener` from 5.4.1 to 5.4.2, resolving the `RUSTSEC-2026-0221` thread-safety warning in the Linux accessibility dependency path.
+- `cargo audit --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195` reports no remaining vulnerabilities. Informational unmaintained warnings remain in resolved transitive dependencies; the GTK3/GLib entries reported from the all-target lockfile are not present in either the Windows stable or Linux beta target graph.

--- a/docs/linux-beta-release-checklist.md
+++ b/docs/linux-beta-release-checklist.md
@@ -11,7 +11,7 @@ Use this checklist with `docs/release-process.md`.
 - Confirm the CI contract still matches reality: `.github/workflows/ci.yml` runs separate Windows and Linux beta jobs, and the Linux beta job still verifies formatting, Linux clippy, `libs/os_api` tests, Linux binary tests, and the Linux release build on `ubuntu-24.04`.
 - Confirm no project docs claim full cross-platform support, Linux stable parity, AppImage support, or Flatpak support.
 - Confirm no docs or release notes claim saved-rule desktop shortcut, quick shortcut launch, or `.desktop` launcher parity for Linux beta; the Windows shortcut button remains hidden on non-Windows.
-- Confirm Linux beta does not expose or start Windows Event Log diagnostics; the schema v9 preference field remains unused on Linux and v8/older state adopts the enabled default without eager rewrite.
+- Confirm Linux beta does not expose or start Windows Event Log diagnostics; the persisted preference remains unused on Linux and v8/older state adopts the enabled default without eager rewrite.
 - Confirm `README.md` and `AGENTS.md` describe Linux as a desktop beta path with prerelease artifacts under `linux-beta-v*` tags.
 - Confirm the base version in `Cargo.toml` matches the `X.Y.Z` segment of the Linux beta tag you plan to push.
 - Confirm the beta changelog exists at `changelogs/linux-beta-vX.Y.Z-N.txt`.


### PR DESCRIPTION
## Summary

- bump the application and lockfile version to 1.6.0
- add complete stable release notes and promote the consolidated changelog entry
- update webbrowser to 1.2.2 and event-listener to 5.4.2 after the release audit
- refresh the documented quick-xml exceptions and Linux beta checklist wording

## Verification

- cargo fmt --all -- --check
- cargo test --locked --manifest-path libs/os_api/Cargo.toml (64 passed)
- Windows clippy and application tests (327 passed)
- release EXE/PDB identity, manifest, and crash-report probes
- Linux feature clippy, tests (308 passed), and release build
- cargo audit with only the two documented quick-xml build-time exceptions ignored

The release notes explicitly do not claim that the exact native crash in #14 was conclusively reproduced.