### PR TITLE
Fix protected process settings failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,7 @@ Current runtime split:
   - `running_apps`
   - runtime-only installed-package metadata cache for Windows installed targets
   - package-owner claims for shared package-local helper processes
-  - cached app statuses
+  - cached app statuses; a contention-time settings mismatch remains visible until a manual or monitor-confirmed successful settings application clears it
   - `monitor_rx`
 - runtime process identity stays keyed by opaque `AppRuntimeKey`, but tracked app ownership now also stores logical `GroupId` / `RuleId`
 - shell presenters are owned under `shell::presenters`; their source files still live under `src/app/views/` via path-based module ownership

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,6 +296,7 @@ Data source separation:
 - opening crash-report directories and selecting report files through an Explorer shell process whose token is verified non-elevated and below high integrity; the pre-existing Activity data-folder action retains its direct Explorer launch contract
 - bounded read-only lookup of matching local Windows Application Event Log records for enabled-by-default diagnostics
 - process-instance token lookup used to prevent retained/reused PIDs from being managed as a different process instance
+- Windows affinity/priority application labels the failed Win32 operation and, after an access-denied settings open, may read `ProcessProtectionLevelInfo` through a query-limited handle to explain a confirmed protected-process denial; it never changes protection or privileges
 - resolving the current elevated token's per-user Desktop directory for Windows shortcut creation
 - Windows shortcut creation for saved-rule launch shortcuts
 - affinity read and set

--- a/libs/os_api/src/windows/common.rs
+++ b/libs/os_api/src/windows/common.rs
@@ -16,6 +16,11 @@ use crate::PriorityClass;
 #[derive(Debug)]
 pub(super) enum OsError {
     Win(windows::core::Error),
+    Operation {
+        operation: &'static str,
+        pid: u32,
+        source: windows::core::Error,
+    },
     Msg(String),
 }
 
@@ -23,6 +28,11 @@ impl std::fmt::Display for OsError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             OsError::Win(e) => write!(f, "{e}"),
+            OsError::Operation {
+                operation,
+                pid,
+                source,
+            } => write!(f, "{operation} failed for PID {pid}: {source}"),
             OsError::Msg(s) => write!(f, "{s}"),
         }
     }
@@ -55,7 +65,13 @@ impl Drop for ComGuard {
 }
 
 pub(super) fn open_process(pid: u32, access: PROCESS_ACCESS_RIGHTS) -> Result<HANDLE, OsError> {
-    unsafe { Ok(OpenProcess(access, false, pid)?) }
+    unsafe {
+        OpenProcess(access, false, pid).map_err(|source| OsError::Operation {
+            operation: "OpenProcess",
+            pid,
+            source,
+        })
+    }
 }
 
 pub(super) fn transform_to_win_priority(p: PriorityClass) -> PROCESS_CREATION_FLAGS {

--- a/libs/os_api/src/windows/scheduling.rs
+++ b/libs/os_api/src/windows/scheduling.rs
@@ -39,8 +39,7 @@ impl OS {
             GetProcessTimes(handle, &mut created, &mut exited, &mut kernel, &mut user).map_err(
                 |error| OsError::Msg(format!("GetProcessTimes failed for PID {pid}: {error}")),
             )?;
-            let instance_token =
-                ((created.dwHighDateTime as u64) << 32) | created.dwLowDateTime as u64;
+            let instance_token = process_instance_token(&created);
             if instance_token != expected_instance_token {
                 return Err(OsError::Msg(
                     "process instance no longer matches the tracked PID".into(),
@@ -212,10 +211,7 @@ fn process_has_protection_level(pid: u32, expected_instance_token: u64) -> bool 
         if GetProcessTimes(handle, &mut created, &mut exited, &mut kernel, &mut user).is_err() {
             return false;
         }
-        let instance_token = ((created.dwHighDateTime as u64) << 32) | created.dwLowDateTime as u64;
-        if instance_token != expected_instance_token {
-            return false;
-        }
+        let instance_token = process_instance_token(&created);
         let mut info = PROCESS_PROTECTION_LEVEL_INFORMATION::default();
 
         GetProcessInformation(
@@ -225,8 +221,24 @@ fn process_has_protection_level(pid: u32, expected_instance_token: u64) -> bool 
             std::mem::size_of::<PROCESS_PROTECTION_LEVEL_INFORMATION>() as u32,
         )
         .is_ok()
-            && is_protected_level(info.ProtectionLevel)
+            && is_confirmed_protected_process(
+                expected_instance_token,
+                instance_token,
+                info.ProtectionLevel,
+            )
     }
+}
+
+fn process_instance_token(created: &FILETIME) -> u64 {
+    ((created.dwHighDateTime as u64) << 32) | created.dwLowDateTime as u64
+}
+
+fn is_confirmed_protected_process(
+    expected_instance_token: u64,
+    observed_instance_token: u64,
+    protection_level: windows::Win32::System::Threading::PROCESS_PROTECTION_LEVEL,
+) -> bool {
+    expected_instance_token == observed_instance_token && is_protected_level(protection_level)
 }
 
 fn is_protected_level(level: windows::Win32::System::Threading::PROCESS_PROTECTION_LEVEL) -> bool {
@@ -235,7 +247,7 @@ fn is_protected_level(level: windows::Win32::System::Threading::PROCESS_PROTECTI
 
 #[cfg(test)]
 mod tests {
-    use super::{OsError, is_access_denied, is_protected_level};
+    use super::{OsError, is_access_denied, is_confirmed_protected_process, is_protected_level};
     use windows::Win32::Foundation::ERROR_ACCESS_DENIED;
     use windows::Win32::System::Threading::{PROTECTION_LEVEL_NONE, PROTECTION_LEVEL_WINTCB_LIGHT};
     use windows::core::{Error, HRESULT};
@@ -256,5 +268,24 @@ mod tests {
     fn protection_level_none_is_not_protected_but_wintcb_light_is() {
         assert!(!is_protected_level(PROTECTION_LEVEL_NONE));
         assert!(is_protected_level(PROTECTION_LEVEL_WINTCB_LIGHT));
+    }
+
+    #[test]
+    fn protection_diagnostic_rejects_a_reused_pid_instance() {
+        assert!(!is_confirmed_protected_process(
+            100,
+            101,
+            PROTECTION_LEVEL_WINTCB_LIGHT
+        ));
+        assert!(!is_confirmed_protected_process(
+            100,
+            100,
+            PROTECTION_LEVEL_NONE
+        ));
+        assert!(is_confirmed_protected_process(
+            100,
+            100,
+            PROTECTION_LEVEL_WINTCB_LIGHT
+        ));
     }
 }

--- a/libs/os_api/src/windows/scheduling.rs
+++ b/libs/os_api/src/windows/scheduling.rs
@@ -1,9 +1,11 @@
-use windows::Win32::Foundation::FILETIME;
+use windows::Win32::Foundation::{ERROR_ACCESS_DENIED, FILETIME, HANDLE};
 use windows::Win32::System::Threading::{
-    GetCurrentProcess, GetPriorityClass, GetProcessAffinityMask, GetProcessTimes,
-    PROCESS_QUERY_INFORMATION, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SET_INFORMATION,
-    SetPriorityClass, SetProcessAffinityMask,
+    GetCurrentProcess, GetPriorityClass, GetProcessAffinityMask, GetProcessInformation,
+    GetProcessTimes, PROCESS_PROTECTION_LEVEL_INFORMATION, PROCESS_QUERY_INFORMATION,
+    PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SET_INFORMATION, PROTECTION_LEVEL_NONE,
+    ProcessProtectionLevelInfo, SetPriorityClass, SetProcessAffinityMask,
 };
+use windows::core::HRESULT;
 
 use crate::{PriorityClass, ProcessSettingsApplyOutcome};
 
@@ -27,17 +29,16 @@ impl OS {
         }
 
         (|| unsafe {
-            let access = PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_SET_INFORMATION;
-            let handle = open_process(pid, access).or_else(|_| {
-                open_process(pid, PROCESS_QUERY_INFORMATION | PROCESS_SET_INFORMATION)
-            })?;
+            let handle = open_process_for_settings(pid, expected_instance_token)?;
             let _hg = HandleGuard(handle);
 
             let mut created = FILETIME::default();
             let mut exited = FILETIME::default();
             let mut kernel = FILETIME::default();
             let mut user = FILETIME::default();
-            GetProcessTimes(handle, &mut created, &mut exited, &mut kernel, &mut user)?;
+            GetProcessTimes(handle, &mut created, &mut exited, &mut kernel, &mut user).map_err(
+                |error| OsError::Msg(format!("GetProcessTimes failed for PID {pid}: {error}")),
+            )?;
             let instance_token =
                 ((created.dwHighDateTime as u64) << 32) | created.dwLowDateTime as u64;
             if instance_token != expected_instance_token {
@@ -48,19 +49,34 @@ impl OS {
 
             let mut current_mask = 0usize;
             let mut system_mask = 0usize;
-            GetProcessAffinityMask(handle, &mut current_mask, &mut system_mask)?;
+            GetProcessAffinityMask(handle, &mut current_mask, &mut system_mask).map_err(
+                |error| {
+                    OsError::Msg(format!(
+                        "GetProcessAffinityMask failed for PID {pid}: {error}"
+                    ))
+                },
+            )?;
             let current_priority = GetPriorityClass(handle);
             if current_priority == 0 {
-                return Err(OsError::Msg("GetPriorityClass returned 0".into()));
+                return Err(OsError::Msg(format!(
+                    "GetPriorityClass failed for PID {pid}: {}",
+                    windows::core::Error::from_thread()
+                )));
             }
             let previous_priority = from_win_priority(current_priority);
             let affinity_changed = current_mask != mask;
             let priority_changed = previous_priority != priority;
             if apply_changes && affinity_changed {
-                SetProcessAffinityMask(handle, mask)?;
+                SetProcessAffinityMask(handle, mask).map_err(|error| {
+                    OsError::Msg(format!(
+                        "SetProcessAffinityMask failed for PID {pid}: {error}"
+                    ))
+                })?;
             }
             if apply_changes && priority_changed {
-                SetPriorityClass(handle, transform_to_win_priority(priority))?;
+                SetPriorityClass(handle, transform_to_win_priority(priority)).map_err(|error| {
+                    OsError::Msg(format!("SetPriorityClass failed for PID {pid}: {error}"))
+                })?;
             }
 
             Ok(ProcessSettingsApplyOutcome {
@@ -122,7 +138,11 @@ impl OS {
             let handle = open_process(pid, PROCESS_SET_INFORMATION)?;
             let _hg = HandleGuard(handle);
 
-            SetProcessAffinityMask(handle, mask)?;
+            SetProcessAffinityMask(handle, mask).map_err(|error| {
+                OsError::Msg(format!(
+                    "SetProcessAffinityMask failed for PID {pid}: {error}"
+                ))
+            })?;
             Ok(())
         })()
         .map_err(|e: OsError| format!("Failed to set affinity mask for process {}: {}", pid, e))
@@ -134,7 +154,9 @@ impl OS {
             let handle = open_process(pid, PROCESS_SET_INFORMATION)?;
             let _hg = HandleGuard(handle);
 
-            SetPriorityClass(handle, transform_to_win_priority(priority))?;
+            SetPriorityClass(handle, transform_to_win_priority(priority)).map_err(|error| {
+                OsError::Msg(format!("SetPriorityClass failed for PID {pid}: {error}"))
+            })?;
             Ok(())
         })()
         .map_err(|e: OsError| format!("Failed to set priority for process {}: {}", pid, e))
@@ -147,5 +169,92 @@ impl OS {
             SetPriorityClass(handle, transform_to_win_priority(priority))
                 .map_err(|e| format!("Failed to set current process priority: {}", e))
         }
+    }
+}
+
+fn open_process_for_settings(pid: u32, expected_instance_token: u64) -> Result<HANDLE, OsError> {
+    let primary_access = PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_SET_INFORMATION;
+    match open_process(pid, primary_access) {
+        Ok(handle) => Ok(handle),
+        Err(primary_error) => {
+            match open_process(pid, PROCESS_QUERY_INFORMATION | PROCESS_SET_INFORMATION) {
+                Ok(handle) => Ok(handle),
+                Err(fallback_error)
+                    if is_access_denied(&primary_error)
+                        && is_access_denied(&fallback_error)
+                        && process_has_protection_level(pid, expected_instance_token) =>
+                {
+                    Err(OsError::Msg(format!(
+                        "OpenProcess failed for PID {pid}: Windows protects this process; affinity and priority changes are not permitted"
+                    )))
+                }
+                Err(fallback_error) => Err(fallback_error),
+            }
+        }
+    }
+}
+
+fn is_access_denied(error: &OsError) -> bool {
+    matches!(error, OsError::Win(error) if error.code() == HRESULT::from_win32(ERROR_ACCESS_DENIED.0))
+        || matches!(error, OsError::Operation { source, .. } if source.code() == HRESULT::from_win32(ERROR_ACCESS_DENIED.0))
+}
+
+fn process_has_protection_level(pid: u32, expected_instance_token: u64) -> bool {
+    unsafe {
+        let Ok(handle) = open_process(pid, PROCESS_QUERY_LIMITED_INFORMATION) else {
+            return false;
+        };
+        let _guard = HandleGuard(handle);
+        let mut created = FILETIME::default();
+        let mut exited = FILETIME::default();
+        let mut kernel = FILETIME::default();
+        let mut user = FILETIME::default();
+        if GetProcessTimes(handle, &mut created, &mut exited, &mut kernel, &mut user).is_err() {
+            return false;
+        }
+        let instance_token = ((created.dwHighDateTime as u64) << 32) | created.dwLowDateTime as u64;
+        if instance_token != expected_instance_token {
+            return false;
+        }
+        let mut info = PROCESS_PROTECTION_LEVEL_INFORMATION::default();
+
+        GetProcessInformation(
+            handle,
+            ProcessProtectionLevelInfo,
+            &mut info as *mut _ as *mut core::ffi::c_void,
+            std::mem::size_of::<PROCESS_PROTECTION_LEVEL_INFORMATION>() as u32,
+        )
+        .is_ok()
+            && is_protected_level(info.ProtectionLevel)
+    }
+}
+
+fn is_protected_level(level: windows::Win32::System::Threading::PROCESS_PROTECTION_LEVEL) -> bool {
+    level != PROTECTION_LEVEL_NONE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OsError, is_access_denied, is_protected_level};
+    use windows::Win32::Foundation::ERROR_ACCESS_DENIED;
+    use windows::Win32::System::Threading::{PROTECTION_LEVEL_NONE, PROTECTION_LEVEL_WINTCB_LIGHT};
+    use windows::core::{Error, HRESULT};
+
+    #[test]
+    fn access_denied_open_process_error_keeps_its_operation_context() {
+        let error = OsError::Operation {
+            operation: "OpenProcess",
+            pid: 42,
+            source: Error::from_hresult(HRESULT::from_win32(ERROR_ACCESS_DENIED.0)),
+        };
+
+        assert!(is_access_denied(&error));
+        assert!(error.to_string().contains("OpenProcess failed for PID 42"));
+    }
+
+    #[test]
+    fn protection_level_none_is_not_protected_but_wintcb_light_is() {
+        assert!(!is_protected_level(PROTECTION_LEVEL_NONE));
+        assert!(is_protected_level(PROTECTION_LEVEL_WINTCB_LIGHT));
     }
 }

--- a/src/app/features/execution/launch.rs
+++ b/src/app/features/execution/launch.rs
@@ -321,15 +321,7 @@ fn reapply_existing_app_settings<O: LaunchOs>(
             return LaunchDispatchOutcome::Rejected(message);
         }
     };
-    let mut failures = Vec::new();
-
-    for &(pid, instance_token) in &instances {
-        if let Err(error) =
-            os.apply_process_settings_if_instance(pid, instance_token, mask, app_to_run.priority)
-        {
-            failures.push(format!("PID {pid}: {error}"));
-        }
-    }
+    let failures = apply_settings_for_instances(os, &instances, mask, app_to_run.priority);
 
     if !failures.is_empty() {
         let _ = runtime.mark_running_app_settings_mismatched(&app_key);
@@ -364,6 +356,25 @@ fn reapply_existing_app_settings<O: LaunchOs>(
             LaunchDispatchOutcome::Rejected(message)
         }
     }
+}
+
+fn apply_settings_for_instances<O: LaunchOs>(
+    os: &O,
+    instances: &[(u32, ProcessInstanceToken)],
+    mask: usize,
+    priority: PriorityClass,
+) -> Vec<String> {
+    let mut failures = Vec::new();
+
+    for &(pid, instance_token) in instances {
+        if let Err(error) =
+            os.apply_process_settings_if_instance(pid, instance_token, mask, priority)
+        {
+            failures.push(format!("PID {pid}: {error}"));
+        }
+    }
+
+    failures
 }
 
 fn focus_existing_app<O: LaunchOs>(
@@ -480,13 +491,27 @@ fn run_launch_decision<O: LaunchOs>(
 
     match runtime.lookup_running_app_instances(&app_key) {
         RunningAppInstancesLookup::Found(instances) if !instances.is_empty() => {
-            for &(pid, instance_token) in &instances {
-                let _ = os.apply_process_settings_if_instance(
-                    pid,
-                    instance_token,
-                    mask,
-                    app_to_run.priority,
+            let failures = apply_settings_for_instances(os, &instances, mask, app_to_run.priority);
+            if !failures.is_empty() {
+                match runtime.try_mark_running_app_settings_mismatched(&app_key) {
+                    RunningAppSettingsUpdate::Updated => {}
+                    RunningAppSettingsUpdate::NotFound => log_manager.add_important_entry(format!(
+                        "Failed to record settings mismatch for {} because its tracked entry disappeared",
+                        app_to_run.display()
+                    )),
+                    RunningAppSettingsUpdate::Busy => log_manager.add_important_entry(format!(
+                        "Failed to record settings mismatch for {} because running app state is temporarily busy",
+                        app_to_run.display()
+                    )),
+                }
+
+                let message = format!(
+                    "Failed to reapply settings for {}: {}",
+                    app_to_run.display(),
+                    failures.join("; ")
                 );
+                log_manager.add_important_entry(message.clone());
+                return LaunchDispatchOutcome::Rejected(message);
             }
 
             let was_focused = instances.iter().any(|&(pid, expected_token)| {
@@ -1281,6 +1306,54 @@ mod tests {
             .entries
             .iter()
             .any(|entry| entry.message.contains("no window found to focus")));
+    }
+
+    #[test]
+    fn test_already_running_apply_failure_is_rejected_mismatched_and_never_logs_reapplied() {
+        let mut runtime = RuntimeRegistry::new();
+        let app = sample_app();
+        let app_key = app.get_key();
+        assert!(runtime.add_running_app_with_token(&app_key, 77, 1077, group_id(0), rule_id(0)));
+        assert!(runtime.add_pid_to_existing_app_with_token(&app_key, 78, 1078));
+        let mut log_manager = LogManager::default();
+        let os = FakeLaunchOs {
+            affinity_results: HashMap::from([(
+                77,
+                Err("SetProcessAffinityMask: Windows protects this process; affinity and priority changes are not permitted".to_string()),
+            )]),
+            focus_results: HashMap::from([(77, true)]),
+            ..Default::default()
+        };
+
+        let outcome = run_launch_decision(
+            &runtime,
+            &mut log_manager,
+            group_id(0),
+            rule_id(0),
+            app,
+            vec![0, 1],
+            &os,
+        );
+
+        assert!(
+            matches!(outcome, super::LaunchDispatchOutcome::Rejected(message)
+            if message.contains("PID 77")
+                && message.contains("Windows protects this process"))
+        );
+        assert_eq!(
+            runtime.get_app_status_sync(&app_key),
+            AppStatus::SettingsMismatch
+        );
+        assert_eq!(os.affinity_calls.borrow().as_slice(), &[(77, 3), (78, 3)]);
+        assert!(os.focus_calls.borrow().is_empty());
+        assert!(log_manager
+            .entries
+            .iter()
+            .any(|entry| entry.message.contains("PID 77")));
+        assert!(!log_manager
+            .entries
+            .iter()
+            .any(|entry| entry.message.contains("settings reapplied")));
     }
 
     #[test]

--- a/src/app/features/execution/mod.rs
+++ b/src/app/features/execution/mod.rs
@@ -23,6 +23,7 @@ pub use store::RuntimeRegistry;
 pub(crate) use store::{
     cleanup_orphaned_package_owners, ensure_package_owner_claim,
     resolve_installed_package_runtime_info_cached, InstalledPackageTrackingState,
+    RunningAppStatusCache,
 };
 pub use tracking::run_running_app_monitor;
 
@@ -35,6 +36,7 @@ pub(crate) fn is_excluded_installed_auto_process(process_name: &str) -> bool {
 
 pub(crate) fn spawn_monitors_with_wake(
     running_apps: Arc<TokioRwLock<RunningApps>>,
+    running_app_statuses: RunningAppStatusCache,
     installed_package_tracking: Arc<RwLock<InstalledPackageTrackingState>>,
     persistent_state: Arc<RwLock<AppStateStorage>>,
     wake: Option<MonitorWake>,
@@ -49,6 +51,7 @@ pub(crate) fn spawn_monitors_with_wake(
     ));
     tokio::spawn(run_process_settings_monitor(
         running_apps,
+        running_app_statuses,
         persistent_state,
         monitor_tx,
     ));

--- a/src/app/features/execution/reconcile.rs
+++ b/src/app/features/execution/reconcile.rs
@@ -1,6 +1,7 @@
 use crate::app::features::execution::MonitorEventSender;
+use crate::app::features::execution::RunningAppStatusCache;
 use crate::app::features::rules::RulesContext;
-use crate::app::models::{AppRuntimeKey, AppStateStorage, RunningApps};
+use crate::app::models::{AppRuntimeKey, AppStateStorage, AppStatus, RunningApps};
 use crate::app::shared::ids::{GroupId, RuleId};
 use crate::app::shell::events::ShellEvent;
 use os_api::{PriorityClass, ProcessSettingsApplyOutcome, OS};
@@ -57,6 +58,7 @@ impl ProcessSettingsOs for RealProcessSettingsOs {
 
 pub async fn run_process_settings_monitor(
     running_apps: Arc<TokioRwLock<RunningApps>>,
+    running_app_statuses: RunningAppStatusCache,
     app_state: Arc<RwLock<AppStateStorage>>,
     monitor_tx: MonitorEventSender,
 ) {
@@ -87,6 +89,7 @@ pub async fn run_process_settings_monitor(
                 monitoring_enabled,
                 &mut os,
             );
+            record_confirmed_match_statuses(&apps, &running_app_statuses);
 
             if !outcome.notifications.is_empty() {
                 for message in outcome.notifications {
@@ -99,6 +102,15 @@ pub async fn run_process_settings_monitor(
             if outcome.changed {
                 monitor_tx.try_send(ShellEvent::RuntimeStateChanged);
             }
+        }
+    }
+}
+
+fn record_confirmed_match_statuses(apps: &RunningApps, statuses: &RunningAppStatusCache) {
+    let mut statuses = statuses.write().unwrap();
+    for (app_key, app) in &apps.apps {
+        if app.settings_matched && statuses.get(app_key) == Some(&AppStatus::SettingsMismatch) {
+            statuses.insert(app_key.clone(), AppStatus::Running);
         }
     }
 }
@@ -215,12 +227,18 @@ fn process_settings_iteration_with_os<O: ProcessSettingsOs>(
 
 #[cfg(test)]
 mod tests {
-    use super::{affinity_mask_from_cores, process_settings_iteration_with_os, ProcessSettingsOs};
-    use crate::app::models::{AppStateStorage, AppToRun, CoreGroup, CpuSchema, RunningApps};
+    use super::{
+        affinity_mask_from_cores, process_settings_iteration_with_os,
+        record_confirmed_match_statuses, ProcessSettingsOs,
+    };
+    use crate::app::models::{
+        AppStateStorage, AppStatus, AppToRun, CoreGroup, CpuSchema, RunningApps,
+    };
     use crate::app::shared::ids::{GroupId, RuleId};
     use os_api::{PriorityClass, ProcessSettingsApplyOutcome};
     use std::collections::HashMap;
     use std::path::PathBuf;
+    use std::sync::{Arc, RwLock};
 
     struct FakeProcessSettingsOs {
         affinity: HashMap<u32, usize>,
@@ -444,6 +462,37 @@ mod tests {
         assert!(second.changed);
         assert!(second.notifications.is_empty());
         assert!(apps.apps.get(&key).unwrap().settings_matched);
+    }
+
+    #[test]
+    fn test_confirmed_monitor_correction_clears_a_pessimistic_mismatch_hint() {
+        let state = sample_state();
+        let key = state.groups[1].programs[0].get_key();
+        let mut apps = RunningApps::default();
+        apps.add_app(&key, 90, group_id(1), rule_id(0));
+        let statuses = Arc::new(RwLock::new(HashMap::from([(
+            key.clone(),
+            AppStatus::SettingsMismatch,
+        )])));
+        let mut os = FakeProcessSettingsOs::new(
+            HashMap::from([(90, 0b001)]),
+            HashMap::from([(90, PriorityClass::Normal)]),
+        );
+        seed_tracked_instance(&mut apps, &key, 90, &mut os);
+
+        process_settings_iteration_with_os(&mut apps, &state, true, &mut os);
+        record_confirmed_match_statuses(&apps, &statuses);
+        assert_eq!(
+            statuses.read().unwrap().get(&key),
+            Some(&AppStatus::SettingsMismatch)
+        );
+
+        process_settings_iteration_with_os(&mut apps, &state, true, &mut os);
+        record_confirmed_match_statuses(&apps, &statuses);
+        assert_eq!(
+            statuses.read().unwrap().get(&key),
+            Some(&AppStatus::Running)
+        );
     }
 
     #[test]

--- a/src/app/features/execution/reconcile.rs
+++ b/src/app/features/execution/reconcile.rs
@@ -89,7 +89,8 @@ pub async fn run_process_settings_monitor(
                 monitoring_enabled,
                 &mut os,
             );
-            record_confirmed_match_statuses(&apps, &running_app_statuses);
+            let status_cache_changed =
+                record_confirmed_match_statuses(&apps, &running_app_statuses);
 
             if !outcome.notifications.is_empty() {
                 for message in outcome.notifications {
@@ -99,20 +100,23 @@ pub async fn run_process_settings_monitor(
                 }
             }
 
-            if outcome.changed {
+            if outcome.changed || status_cache_changed {
                 monitor_tx.try_send(ShellEvent::RuntimeStateChanged);
             }
         }
     }
 }
 
-fn record_confirmed_match_statuses(apps: &RunningApps, statuses: &RunningAppStatusCache) {
+fn record_confirmed_match_statuses(apps: &RunningApps, statuses: &RunningAppStatusCache) -> bool {
     let mut statuses = statuses.write().unwrap();
+    let mut changed = false;
     for (app_key, app) in &apps.apps {
         if app.settings_matched && statuses.get(app_key) == Some(&AppStatus::SettingsMismatch) {
             statuses.insert(app_key.clone(), AppStatus::Running);
+            changed = true;
         }
     }
+    changed
 }
 
 fn collect_program_settings(
@@ -481,14 +485,40 @@ mod tests {
         seed_tracked_instance(&mut apps, &key, 90, &mut os);
 
         process_settings_iteration_with_os(&mut apps, &state, true, &mut os);
-        record_confirmed_match_statuses(&apps, &statuses);
+        assert!(!record_confirmed_match_statuses(&apps, &statuses));
         assert_eq!(
             statuses.read().unwrap().get(&key),
             Some(&AppStatus::SettingsMismatch)
         );
 
         process_settings_iteration_with_os(&mut apps, &state, true, &mut os);
-        record_confirmed_match_statuses(&apps, &statuses);
+        assert!(record_confirmed_match_statuses(&apps, &statuses));
+        assert_eq!(
+            statuses.read().unwrap().get(&key),
+            Some(&AppStatus::Running)
+        );
+    }
+
+    #[test]
+    fn test_confirmed_match_cache_transition_is_reported_without_a_process_state_change() {
+        let state = sample_state();
+        let key = state.groups[0].programs[0].get_key();
+        let mut apps = RunningApps::default();
+        apps.add_app(&key, 91, group_id(0), rule_id(0));
+        let statuses = Arc::new(RwLock::new(HashMap::from([(
+            key.clone(),
+            AppStatus::SettingsMismatch,
+        )])));
+        let mut os = FakeProcessSettingsOs::new(
+            HashMap::from([(91, 0b001)]),
+            HashMap::from([(91, PriorityClass::Normal)]),
+        );
+        seed_tracked_instance(&mut apps, &key, 91, &mut os);
+
+        let outcome = process_settings_iteration_with_os(&mut apps, &state, true, &mut os);
+
+        assert!(!outcome.changed);
+        assert!(record_confirmed_match_statuses(&apps, &statuses));
         assert_eq!(
             statuses.read().unwrap().get(&key),
             Some(&AppStatus::Running)

--- a/src/app/features/execution/store.rs
+++ b/src/app/features/execution/store.rs
@@ -10,7 +10,7 @@ use tokio::sync::RwLock as TokioRwLock;
 pub struct ExecutionStore {
     running_apps: Arc<TokioRwLock<RunningApps>>,
     installed_package_tracking: Arc<RwLock<InstalledPackageTrackingState>>,
-    running_apps_statuses: HashMap<AppRuntimeKey, AppStatus>,
+    running_apps_statuses: Arc<RwLock<HashMap<AppRuntimeKey, AppStatus>>>,
 }
 
 #[derive(Debug, Default)]
@@ -59,7 +59,7 @@ impl ExecutionStore {
             installed_package_tracking: Arc::new(RwLock::new(
                 InstalledPackageTrackingState::default(),
             )),
-            running_apps_statuses: HashMap::new(),
+            running_apps_statuses: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -163,10 +163,15 @@ impl ExecutionStore {
             } else {
                 AppStatus::NotRunning
             };
-            self.running_apps_statuses.insert(app_key.clone(), status);
+            self.running_apps_statuses
+                .write()
+                .unwrap()
+                .insert(app_key.clone(), status);
             status
         } else {
             self.running_apps_statuses
+                .read()
+                .unwrap()
                 .get(app_key)
                 .copied()
                 .unwrap_or(AppStatus::NotRunning)
@@ -219,6 +224,32 @@ impl ExecutionStore {
         self.set_running_app_settings_state(app_key, RunningAppSettingsState::Mismatched)
     }
 
+    pub(crate) fn try_mark_running_app_settings_mismatched(
+        &self,
+        app_key: &AppRuntimeKey,
+    ) -> RunningAppSettingsUpdate {
+        let outcome = match self.running_apps.try_write() {
+            Ok(mut apps) => match apps.apps.get_mut(app_key) {
+                Some(app) => {
+                    app.settings_matched = false;
+                    RunningAppSettingsUpdate::Updated
+                }
+                None => RunningAppSettingsUpdate::NotFound,
+            },
+            Err(_) => RunningAppSettingsUpdate::Busy,
+        };
+
+        if outcome == RunningAppSettingsUpdate::Updated || outcome == RunningAppSettingsUpdate::Busy
+        {
+            self.running_apps_statuses
+                .write()
+                .unwrap()
+                .insert(app_key.clone(), AppStatus::SettingsMismatch);
+        }
+
+        outcome
+    }
+
     fn set_running_app_settings_state(
         &mut self,
         app_key: &AppRuntimeKey,
@@ -243,7 +274,10 @@ impl ExecutionStore {
             || (outcome == RunningAppSettingsUpdate::Busy
                 && state == RunningAppSettingsState::Mismatched)
         {
-            self.running_apps_statuses.insert(app_key.clone(), status);
+            self.running_apps_statuses
+                .write()
+                .unwrap()
+                .insert(app_key.clone(), status);
         }
         outcome
     }
@@ -341,6 +375,13 @@ impl RuntimeRegistry {
         app_key: &AppRuntimeKey,
     ) -> RunningAppSettingsUpdate {
         self.store.mark_running_app_settings_mismatched(app_key)
+    }
+
+    pub(crate) fn try_mark_running_app_settings_mismatched(
+        &self,
+        app_key: &AppRuntimeKey,
+    ) -> RunningAppSettingsUpdate {
+        self.store.try_mark_running_app_settings_mismatched(app_key)
     }
 }
 
@@ -548,6 +589,21 @@ mod tests {
         let _write_guard = running_apps.try_write().unwrap();
         assert_eq!(
             store.mark_running_app_settings_matched(&key),
+            RunningAppSettingsUpdate::Busy
+        );
+        assert_eq!(store.get_app_status_sync(&key), AppStatus::SettingsMismatch);
+    }
+
+    #[test]
+    fn test_busy_try_mismatch_marks_the_cached_status() {
+        let mut store = ExecutionStore::new();
+        let key = installed_app("Sample", "Pkg!App", PriorityClass::Normal).get_key();
+        assert!(store.add_running_app(&key, 42, group_id(0), rule_id(0)));
+
+        let running_apps = store.running_apps_handle();
+        let _write_guard = running_apps.try_write().unwrap();
+        assert_eq!(
+            store.try_mark_running_app_settings_mismatched(&key),
             RunningAppSettingsUpdate::Busy
         );
         assert_eq!(store.get_app_status_sync(&key), AppStatus::SettingsMismatch);

--- a/src/app/features/execution/store.rs
+++ b/src/app/features/execution/store.rs
@@ -154,7 +154,7 @@ impl ExecutionStore {
 
     pub fn get_app_status_sync(&mut self, app_key: &AppRuntimeKey) -> AppStatus {
         if let Ok(apps) = self.running_apps.try_read() {
-            let status = if let Some(app) = apps.apps.get(app_key) {
+            let canonical_status = if let Some(app) = apps.apps.get(app_key) {
                 if app.settings_matched {
                     AppStatus::Running
                 } else {
@@ -163,10 +163,17 @@ impl ExecutionStore {
             } else {
                 AppStatus::NotRunning
             };
-            self.running_apps_statuses
-                .write()
-                .unwrap()
-                .insert(app_key.clone(), status);
+            let mut statuses = self.running_apps_statuses.write().unwrap();
+            let status = if canonical_status == AppStatus::Running
+                && statuses.get(app_key) == Some(&AppStatus::SettingsMismatch)
+            {
+                // A failed reapply can race a monitor writer. Keep the pessimistic result until
+                // a later successful settings application explicitly confirms a match.
+                AppStatus::SettingsMismatch
+            } else {
+                canonical_status
+            };
+            statuses.insert(app_key.clone(), status);
             status
         } else {
             self.running_apps_statuses
@@ -606,6 +613,7 @@ mod tests {
             store.try_mark_running_app_settings_mismatched(&key),
             RunningAppSettingsUpdate::Busy
         );
+        drop(_write_guard);
         assert_eq!(store.get_app_status_sync(&key), AppStatus::SettingsMismatch);
     }
 }

--- a/src/app/features/execution/store.rs
+++ b/src/app/features/execution/store.rs
@@ -6,11 +6,13 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use tokio::sync::RwLock as TokioRwLock;
 
+pub(crate) type RunningAppStatusCache = Arc<RwLock<HashMap<AppRuntimeKey, AppStatus>>>;
+
 #[derive(Default)]
 pub struct ExecutionStore {
     running_apps: Arc<TokioRwLock<RunningApps>>,
     installed_package_tracking: Arc<RwLock<InstalledPackageTrackingState>>,
-    running_apps_statuses: Arc<RwLock<HashMap<AppRuntimeKey, AppStatus>>>,
+    running_apps_statuses: RunningAppStatusCache,
 }
 
 #[derive(Debug, Default)]
@@ -65,6 +67,10 @@ impl ExecutionStore {
 
     pub fn running_apps_handle(&self) -> Arc<TokioRwLock<RunningApps>> {
         self.running_apps.clone()
+    }
+
+    pub(crate) fn running_app_statuses_handle(&self) -> RunningAppStatusCache {
+        self.running_apps_statuses.clone()
     }
 
     pub fn installed_package_tracking_handle(&self) -> Arc<RwLock<InstalledPackageTrackingState>> {
@@ -300,6 +306,10 @@ impl RuntimeRegistry {
 
     pub fn running_apps_handle(&self) -> Arc<TokioRwLock<RunningApps>> {
         self.store.running_apps_handle()
+    }
+
+    pub(crate) fn running_app_statuses_handle(&self) -> RunningAppStatusCache {
+        self.store.running_app_statuses_handle()
     }
 
     pub fn installed_package_tracking_handle(&self) -> Arc<RwLock<InstalledPackageTrackingState>> {

--- a/src/app/shell/app.rs
+++ b/src/app/shell/app.rs
@@ -204,9 +204,10 @@ impl App {
         let monitor_ctx = cc.egui_ctx.clone();
         Self::bootstrap_runtime_without_startup(
             &mut state,
-            move |running_apps, package_tracking, persistent_state| {
+            move |running_apps, running_app_statuses, package_tracking, persistent_state| {
                 execution::spawn_monitors_with_wake(
                     running_apps,
+                    running_app_statuses,
                     package_tracking,
                     persistent_state,
                     Some(Arc::new(move || monitor_ctx.request_repaint())),
@@ -331,6 +332,7 @@ impl App {
     ) where
         F: FnOnce(
             Arc<TokioRwLock<RunningApps>>,
+            execution::RunningAppStatusCache,
             Arc<RwLock<InstalledPackageTrackingState>>,
             Arc<RwLock<crate::app::models::AppStateStorage>>,
         ) -> MonitorEventReceiver,
@@ -343,6 +345,7 @@ impl App {
     where
         F: FnOnce(
             Arc<TokioRwLock<RunningApps>>,
+            execution::RunningAppStatusCache,
             Arc<RwLock<InstalledPackageTrackingState>>,
             Arc<RwLock<crate::app::models::AppStateStorage>>,
         ) -> MonitorEventReceiver,
@@ -350,6 +353,7 @@ impl App {
         diagnostics::log_startup(&mut state.log_manager, &state.persistent_state);
         state.runtime.monitor_rx = Some(spawn_monitors(
             state.runtime.running_apps_handle(),
+            state.runtime.running_app_statuses_handle(),
             state.runtime.installed_package_tracking_handle(),
             state.persistent_state.clone(),
         ));
@@ -780,7 +784,7 @@ mod tests {
             &mut state,
             &ctx,
             StartupIntent::NormalGui,
-            move |_, _, _| rx,
+            move |_, _, _, _| rx,
         );
 
         assert!(state.runtime.monitor_rx.is_some());
@@ -864,7 +868,7 @@ mod tests {
             &mut state,
             &ctx,
             StartupIntent::NormalGui,
-            move |_, _, _| rx,
+            move |_, _, _, _| rx,
         );
 
         let messages = state
@@ -905,7 +909,7 @@ mod tests {
                 group_id,
                 rule_id: requested_rule_id,
             },
-            move |_, _, _| rx,
+            move |_, _, _, _| rx,
         );
 
         let messages = state


### PR DESCRIPTION
## Summary

- Reject an existing-process reapply when any managed PID fails, retain a mismatch status, and never log a false success.
- Add PID-specific Windows operation context and a query-limited protection-level diagnostic for confirmed protected processes.
- Validate the diagnostic against the expected process instance and preserve a pessimistic mismatch status during runtime-lock contention.

## Safety

- No audiodg-specific behavior, registry change, driver, or privilege/protection bypass.
- Protected processes remain unsupported for affinity and priority changes.

## Validation

- `cargo test -p os_api`
- `cargo test --features windows --bin cpu-affinity-tool`
- `cargo test --features linux --bin cpu-affinity-tool-linux`
- Windows/Linux clippy with warnings denied
- Release build, EXE/PDB identity, manifest, formatting, and diff checks

Closes #17
